### PR TITLE
fix rpath for standalone build

### DIFF
--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ROCM_FOUND)
                 ${ROCM_LIBRARIES}
                 -L${ROCM_LIBRARIES_DIR}/../hsa/lib -L${ROCM_LIBRARIES_DIR}
                 -Wl,--enable-new-dtags
-                -Wl,-rpath,\$ORIGIN/../../hsa/lib -Wl,-rpath,\$ORIGIN/../../lib
+                -Wl,-rpath,\$ORIGIN/../hsa/lib -Wl,-rpath,\$ORIGIN/../lib
             )
        else()
             libatmi_runtime_say("Not building ATMI C Extension: GCC Plugin not found.")

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -80,7 +80,8 @@ if(ROCM_FOUND)
                 ${ROCM_LIBRARIES}
                 -L${ROCM_LIBRARIES_DIR}/../hsa/lib -L${ROCM_LIBRARIES_DIR}
                 -Wl,--enable-new-dtags
-                -Wl,-rpath,\$ORIGIN/../hsa/lib -Wl,-rpath,\$ORIGIN/../lib
+                -Wl,-rpath,\$ORIGIN/../../hsa/lib -Wl,-rpath,\$ORIGIN/../../lib
+                -Wl,-rpath,${ROCM_LIBRARIES_DIR}/../hsa/lib -Wl,-rpath,${ROCM_LIBRARIES_DIR}
             )
        else()
             libatmi_runtime_say("Not building ATMI C Extension: GCC Plugin not found.")

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -120,8 +120,10 @@ target_link_libraries(
   -L${ROCM_LIBRARIES_DIR}
   -L${CMAKE_INSTALL_PREFIX}/lib -lamd_hostcall -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib
   -Wl,--enable-new-dtags
-  -Wl,-rpath,\$ORIGIN/../hsa/lib
-  -Wl,-rpath,\$ORIGIN/../lib
+  -Wl,-rpath,\$ORIGIN/../../hsa/lib
+  -Wl,-rpath,\$ORIGIN/../../lib
+  -Wl,-rpath,${ROCM_LIBRARIES_DIR}/../hsa/lib
+  -Wl,-rpath,${ROCM_LIBRARIES_DIR}
 )
 
 # set output dir for .h files

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -120,8 +120,8 @@ target_link_libraries(
   -L${ROCM_LIBRARIES_DIR}
   -L${CMAKE_INSTALL_PREFIX}/lib -lamd_hostcall -Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib
   -Wl,--enable-new-dtags
-  -Wl,-rpath,\$ORIGIN/../../hsa/lib
-  -Wl,-rpath,\$ORIGIN/../../lib
+  -Wl,-rpath,\$ORIGIN/../hsa/lib
+  -Wl,-rpath,\$ORIGIN/../lib
 )
 
 # set output dir for .h files


### PR DESCRIPTION
after review and discussion with Ethan, we decided to remove the extraneous ../  from ORIGIN/../../
as it will fix our standalone build. When ROCm builds next iterate we will revisit this issue, and look at it from the perspective of fixing the ROCm side build of our product.