### PR TITLE
print status code in gpue queue error

### DIFF
--- a/src/runtime/core/ATLMachine.cpp
+++ b/src/runtime/core/ATLMachine.cpp
@@ -135,7 +135,7 @@ int cu_mask_parser(char *gpu_workers, uint64_t *cu_masks, int count)
 
 void callbackQueue(hsa_status_t status, hsa_queue_t *source, void *data) {
   if(status != HSA_STATUS_SUCCESS) {
-    fprintf (stderr, "[%s:%d] GPU error in queue %p\n", __FILE__, __LINE__, source);
+    fprintf (stderr, "[%s:%d] GPU error in queue %p %d\n", __FILE__, __LINE__, source, status);
     abort();
    }
 }


### PR DESCRIPTION
simple tweak to print out the error code that caused the queue error.