### PR TITLE
ATMI Release for ROCm v3.2

### DIFF
--- a/include/atmi_runtime.h
+++ b/include/atmi_runtime.h
@@ -74,6 +74,77 @@ atmi_status_t atmi_finalize();
  * @{
  */
 /**
+ * @brief Register the ATMI code module from file on to a specific place
+ * (device).
+ *
+ * @detail Currently, only GPU devices need explicit module registration because
+ * of their specific ISAs that require a separate compilation phase. On the
+ * other
+ * hand, CPU devices execute regular x86 functions that are compiled with the
+ * host program.
+ *
+ * @param[in] filenames A collection of files that contain the GPU modules
+ * targeting ::AMDGCN platform types. Value cannot be NULL.
+ *
+ * @param[in] types A collection of platform types corresponding to the files.
+ * Value cannot be NULL.
+ *
+ * @param[in] num_modules Size of @p filenames and @p types. Value should be
+ * greater than 0.
+ *
+ * @param[in] place Denotes the execution place (device) on which the module
+ * should be registered and loaded.
+ *
+ * @retval ::ATMI_STATUS_SUCCESS The function has executed successfully.
+ *
+ * @retval ::ATMI_STATUS_ERROR The function encountered errors.
+ *
+ * @retval ::ATMI_STATUS_UNKNOWN The function encountered errors.
+ *
+ */
+atmi_status_t atmi_module_register_to_place(const char **filenames,
+                                            atmi_platform_type_t *types,
+                                            const int num_modules,
+                                            atmi_place_t place);
+
+/**
+ * @brief Register the ATMI code module from memory on to a specific place
+ * (device).
+ *
+ * @detail Currently, only GPU devices need explicit module registration because
+ * of their specific ISAs that require a separate compilation phase. On the
+ * other
+ * hand, CPU devices execute regular x86 functions that are compiled with the
+ * host program.
+ *
+ * @param[in] modules A collection of memory regions that contain the GPU
+ * modules
+ * targeting ::AMDGCN platform types. Value cannot be NULL.
+ *
+ * @param[in] module_sizes Sizes of each module region in @p modules. Value
+ * cannot be NULL.
+ *
+ * @param[in] types A collection of platform types corresponding to the modules.
+ * Value cannot be NULL.
+ *
+ * @param[in] num_modules Size of @p modules. @p module_sizes and @p types.
+ * Value should be greater than 0.
+ *
+ * @param[in] place Denotes the execution place (device) on which the module
+ * should be registered and loaded.
+ *
+ * @retval ::ATMI_STATUS_SUCCESS The function has executed successfully.
+ *
+ * @retval ::ATMI_STATUS_ERROR The function encountered errors.
+ *
+ * @retval ::ATMI_STATUS_UNKNOWN The function encountered errors.
+ *
+ */
+atmi_status_t atmi_module_register_from_memory_to_place(
+    void **modules, size_t *module_sizes, atmi_platform_type_t *types,
+    const int num_modules, atmi_place_t place);
+
+/**
  * @brief Register the ATMI code module from file.
  *
  * @detail Currently, only GPU devices need explicit module registration because
@@ -497,7 +568,7 @@ atmi_status_t atmi_taskgroup_create(atmi_taskgroup_handle_t *group_handle,
 #else
                                     bool ordered, atmi_place_t place
 #endif
-);
+                                    );
 
 /**
  * @brief Release the task group structure, which could be a group of compute

--- a/src/cmake_modules/FindROCm.cmake
+++ b/src/cmake_modules/FindROCm.cmake
@@ -19,11 +19,11 @@ find_path(
     hsa.h
   HINTS
     ${ROC_DIR}/include
-    ${ROCR_DIR}/include
-    ${ROCR_DIR}/include/hsa
-    ${ROCR_DIR}/hsa/include
-    ${ROCR_DIR}/hsa/include/hsa
-    ${ROCR_DIR}
+    ${ROC_DIR}/include/hsa
+    ${ROC_DIR}/hsa/include
+    ${ROC_DIR}/hsa/include/hsa
+    ${ROC_DIR}/hsa
+    ${ROC_DIR}
     /opt/rocm/include
     /opt/rocm/hsa/include
     /usr/local/include
@@ -37,8 +37,7 @@ find_library(
     hsa-runtime64
   HINTS
     ${ROC_DIR}/lib
-    ${ROCR_DIR}/lib
-    ${ROCR_DIR}
+    ${ROC_DIR}
     /opt/rocm/lib
     /opt/rocm/hsa/lib
     /usr/local/lib
@@ -52,8 +51,7 @@ find_library(
     hsakmt
   HINTS
     ${ROC_DIR}/lib
-    ${ROCT_DIR}/lib
-    ${ROCT_DIR}
+    ${ROC_DIR}
     /opt/rocm/lib
     /opt/rocm/hsa/lib
     /usr/local/lib

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -6,15 +6,6 @@
 
 # Enable support for C++11.
 add_definitions(-std=c++11)
-# Find clang
-find_package(LLVM QUIET CONFIG PATHS ${LLVM_DIR} NO_DEFAULT_PATH)
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-include(AddLLVM)
-add_definitions(${LLVM_DEFINITIONS})
-include_directories(${LLVM_INCLUDE_DIRS})
-if(NOT LLVM_FOUND)
-  libatmi_runtime_say_and_exit("LLVM library required to build ATMI to load the HSA code object")
-endif()
 
 # Find libelf
 find_package(LibElf REQUIRED)

--- a/src/runtime/core/atmi.cpp
+++ b/src/runtime/core/atmi.cpp
@@ -37,6 +37,21 @@ atmi_machine_t *atmi_machine_get_info() {
 /*
  * Modules
  */
+atmi_status_t atmi_module_register_from_memory_to_place(
+    void **modules, size_t *module_sizes, atmi_platform_type_t *types,
+    const int num_modules, atmi_place_t place) {
+  return core::Runtime::getInstance().RegisterModuleFromMemory(
+      modules, module_sizes, types, num_modules, place);
+}
+
+atmi_status_t atmi_module_register_to_place(const char **filenames,
+                                            atmi_platform_type_t *types,
+                                            const int num_modules,
+                                            atmi_place_t place) {
+  return core::Runtime::getInstance().RegisterModule(filenames, types,
+                                                     num_modules, place);
+}
+
 atmi_status_t atmi_module_register_from_memory(void **modules,
                                                size_t *module_sizes,
                                                atmi_platform_type_t *types,

--- a/src/runtime/core/task.cpp
+++ b/src/runtime/core/task.cpp
@@ -52,7 +52,6 @@ std::queue<hsa_signal_t> FreeSignalPool;
 extern bool g_atmi_hostcall_required;
 
 std::map<uint64_t, Kernel *> KernelImplMap;
-// std::map<uint64_t, std::vector<std::string> > ModuleMap;
 bool setCallbackToggle = false;
 
 static atl_dep_sync_t g_dep_sync_type =
@@ -290,22 +289,22 @@ void enqueue_barrier(TaskImpl *task, hsa_queue_t *queue,
 
 extern void TaskImpl::wait() {
   TaskWaitTimer.start();
-  // if task is not yet ready, then it has not gotten all resources yet, so we
-  // wait
-  // for resources and then issue a callback; only then we can wait for the
-  // task to
-  // complete
   if (g_dep_sync_type == ATL_SYNC_BARRIER_PKT) {
+    // if task is not yet ready, then it has not gotten all resources yet, so
+    // we wait for resources and then issue a callback; only then we can wait
+    // for the task to complete.
+    // Also, if the callback thread is already active (check the
+    // first_created_tasks_dispatched_ flag), then we do not issue the
+    // callback.
     while (state_ < ATMI_DISPATCHED) {
     }
-    if (state_ < ATMI_EXECUTED) {
+    if (state_ < ATMI_EXECUTED &&
+         !taskgroup_obj_->first_created_tasks_dispatched_.load()) {
       // Now, this task has the resources, so it can get dispatched any time.
       // So, create a barrier packet for current sink tasks and add async
-      // handler
-      // for its completion.
+      // handler for its completion.
       // All dispatched tasks get signal from device-only signal pool. All
-      // async
-      // handlers are registered to interruptible signals
+      // async handlers are registered to interruptible signals
       lock(&mutex_readyq_);
       TaskImplVecTy tasks;
       TaskImplVecTy *dispatched_tasks_ptr = NULL;

--- a/src/runtime/include/rt.h
+++ b/src/runtime/include/rt.h
@@ -82,6 +82,11 @@ class Runtime {
   atmi_machine_t *GetMachineInfo();
   // modules
   atmi_status_t RegisterModuleFromMemory(void **, size_t *,
+                                         atmi_platform_type_t *, const int,
+                                         atmi_place_t);
+  atmi_status_t RegisterModule(const char **, atmi_platform_type_t *, const int,
+                               atmi_place_t);
+  atmi_status_t RegisterModuleFromMemory(void **, size_t *,
                                          atmi_platform_type_t *, const int);
   atmi_status_t RegisterModule(const char **, atmi_platform_type_t *,
                                const int);


### PR DESCRIPTION
* added fixes
* removed LLVM dependency to build host runtime
* added new API to register HSA code object modules per device