### PR TITLE
ATMI Release for ROCm v3.7 extra fixes

### DIFF
--- a/bin/mymcpu
+++ b/bin/mymcpu
@@ -5,7 +5,7 @@
 #
 # Written by Greg Rodgers Gregory.Rodgers@amd.com
 
-PROGVERSION=0.7-7
+PROGVERSION=11.5-0
 
 # Copyright (c) 2018 ADVANCED MICRO DEVICES, INC.  
 # 
@@ -217,14 +217,10 @@ if [ -L "$thisdir/mymcpu" ] ; then
    thisdir=$(getdname $linkfile)
 fi
 GPUTABLE_FILE=${GPUTABLE_FILE:-$thisdir/gputable.txt}
-if [ -f /sbin/lspci ] ; then
-  _LSPCI="/sbin/lspci"
-else
-  _LSPCI="lspci"
-fi
 local _found=0
 if [ -f $GPUTABLE_FILE ] ; then
-   for gpuid in `$_LSPCI -n -m | awk '{print $3 ":" $4}' | tr -d '"' | grep -E '1002|10de'` ; do
+   for sysfsname in `find -L /sys/bus/pci/devices -maxdepth 2 -name uevent | xargs grep -l -E 'DRIVER=amdgpu|DRIVER=nvidia'` ; do
+      gpuid=`cat $sysfsname | grep 'PCI_ID=' | cut -d"=" -f2 | tr '[:upper:]' '[:lower:]'`
       if [ $_found == 0  ] ; then
          entry=`grep -m1 "^$gpuid" $GPUTABLE_FILE`
          if [ $? == 0 ] ; then

--- a/src/cmake_modules/FindROCm.cmake
+++ b/src/cmake_modules/FindROCm.cmake
@@ -75,24 +75,28 @@ set(ROCM_LIBRARIES ${ROCR_LIBRARY} ${ROCT_LIBRARY})
 #message(STATUS "ROCm libraries dir: ${ROCM_LIBRARIES_DIR}")
 
 if(NOT ROCM_VERSION)
-  file(GLOB version_files
-      LIST_DIRECTORIES false
-      /opt/rocm/.info/version*
-      )
-  list(GET version_files 0 version_file)
-  # Compute the version
-  execute_process(
-      COMMAND cat ${version_file}
-      OUTPUT_VARIABLE _rocm_version
-      ERROR_VARIABLE _rocm_error
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_STRIP_TRAILING_WHITESPACE
-      )
-  if(NOT _rocm_error)
-    set(ROCM_VERSION ${_rocm_version} CACHE STRING "Version of ROCm as found in /opt/rocm/.info/version*")
-  else()
-    set(ROCM_VERSION "0.0.0" CACHE STRING "Version of ROCm set to default")
-  endif()
+# Do not use the metapackage version number because it is error-prone.
+# Use ROCr version number directly if there is a way to infer it.
+# Until then, set the ROCm version to 0.0.0 as default.
+#   file(GLOB version_files
+#       LIST_DIRECTORIES false
+#       /opt/rocm/.info/version*
+#       )
+#   list(GET version_files 0 version_file)
+#   # Compute the version
+#   execute_process(
+#       COMMAND cat ${version_file}
+#       OUTPUT_VARIABLE _rocm_version
+#       ERROR_VARIABLE _rocm_error
+#       OUTPUT_STRIP_TRAILING_WHITESPACE
+#       ERROR_STRIP_TRAILING_WHITESPACE
+#       )
+#   if(NOT _rocm_error)
+#     set(ROCM_VERSION ${_rocm_version} CACHE STRING "Version of ROCm as found in /opt/rocm/.info/version*")
+#   else()
+#     set(ROCM_VERSION "0.0.0" CACHE STRING "Version of ROCm set to default")
+#   endif()
+  set(ROCM_VERSION "0.0.0" CACHE STRING "Version of ROCm set to default")
   mark_as_advanced(ROCM_VERSION)
 endif()
 

--- a/src/device_runtime/bc.cmake
+++ b/src/device_runtime/bc.cmake
@@ -178,10 +178,6 @@ macro(add_bc_library name dir)
     list(APPEND device_libs ${ROCM_DEVICE_PATH}/lib/oclc_finite_only_off.amdgcn.bc)
     list(APPEND device_libs ${ROCM_DEVICE_PATH}/lib/oclc_isa_version_${GFXNUM}.amdgcn.bc)
     list(APPEND device_libs ${ROCM_DEVICE_PATH}/lib/oclc_unsafe_math_off.amdgcn.bc)
-    if(${ROCM_VERSION} VERSION_LESS "2.0.0")
-      # this file is no longer linked from ROCm 2.0 onwards
-      list(APPEND device_libs ${ROCM_DEVICE_PATH}/lib/irif.amdgcn.bc)
-    endif()
   endif()
 
   add_custom_command(

--- a/src/runtime/core/system.cpp
+++ b/src/runtime/core/system.cpp
@@ -819,12 +819,7 @@ void init_tasks() {
 }
 
 hsa_status_t callbackEvent(const hsa_amd_event_t *event, void *data) {
-#if (ROCM_VERSION_MAJOR >= 3) || \
-    (ROCM_VERSION_MAJOR >= 2 && ROCM_VERSION_MINOR >= 3)
   if (event->event_type == HSA_AMD_GPU_MEMORY_FAULT_EVENT) {
-#else
-  if (event->event_type == GPU_MEMORY_FAULT_EVENT) {
-#endif
     hsa_amd_gpu_memory_fault_info_t memory_fault = event->memory_fault;
     // memory_fault.agent
     // memory_fault.virtual_address


### PR DESCRIPTION
- Changes to cloc to support multiple AOMP/LLVM/ROCm versions
- Removed manual checks for ROCm metapackage version that was needed for some backward compatibility issues with ROCr. This version of ATMI essentially supports ROCm 2.3+ 