### PR TITLE
File reorganization with backward compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,8 +31,15 @@ set (atmi_VERSION_MINOR 5)
 ################################################################################
 if ( NOT DEFINED CMAKE_INSTALL_PREFIX )
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set (CMAKE_INSTALL_PREFIX "/opt/rocm/atmi" CACHE PATH "default install path" FORCE )
+  set (CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "default install path" FORCE )
 endif()
+endif()
+
+option(FILE_REORG_BACKWARD_COMPATIBILITY "Enable File Reorg with backward compatibility" ON)
+#TODO: The string replace statements can be removed once build scripts changes are merged
+if(FILE_REORG_BACKWARD_COMPATIBILITY)
+  string(REPLACE "/atmi" "" CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+  string(REPLACE "/atmi" "" CPACK_PACKAGING_INSTALL_PREFIX ${CPACK_PACKAGING_INSTALL_PREFIX})
 endif()
 ################################################################################
 # Looking for ROCM...
@@ -61,6 +68,9 @@ add_subdirectory(runtime)
 add_subdirectory(compiler)
 add_subdirectory(device_runtime)
 
+if(FILE_REORG_BACKWARD_COMPATIBILITY)
+  include(atmi-backward-compat.cmake)
+endif()
 # make examples available in local build
 add_custom_command(
   OUTPUT examples
@@ -101,7 +111,7 @@ set ( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.txt" )
 install( FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION share/doc/atmi COMPONENT runtime )
 
 if ( NOT DEFINED CPACK_PACKAGING_INSTALL_PREFIX )
-    set ( CPACK_PACKAGING_INSTALL_PREFIX /opt/rocm/atmi )
+    set ( CPACK_PACKAGING_INSTALL_PREFIX /opt/rocm )
 endif()
 set ( CPACK_GENERATOR "RPM;DEB" CACHE STRING "CPACK Generator to use, e.g. DEB;RPM")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,8 +38,12 @@ endif()
 option(FILE_REORG_BACKWARD_COMPATIBILITY "Enable File Reorg with backward compatibility" ON)
 #TODO: The string replace statements can be removed once build scripts changes are merged
 if(FILE_REORG_BACKWARD_COMPATIBILITY)
-  string(REPLACE "/atmi" "" CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-  string(REPLACE "/atmi" "" CPACK_PACKAGING_INSTALL_PREFIX ${CPACK_PACKAGING_INSTALL_PREFIX})
+  if(CMAKE_INSTALL_PREFIX)
+    string(REPLACE "/atmi" "" CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+  endif()
+  if(CPACK_PACKAGING_INSTALL_PREFIX)
+    string(REPLACE "/atmi" "" CPACK_PACKAGING_INSTALL_PREFIX ${CPACK_PACKAGING_INSTALL_PREFIX})
+  endif()
 endif()
 ################################################################################
 # Looking for ROCM...

--- a/src/atmi-backward-compat.cmake
+++ b/src/atmi-backward-compat.cmake
@@ -1,0 +1,130 @@
+# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+cmake_minimum_required(VERSION 3.16.8)
+
+set(ATMI_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(ATMI_WRAPPER_DIR ${ATMI_BUILD_DIR}/wrapper_dir)
+set(ATMI_WRAPPER_INC_DIR ${ATMI_WRAPPER_DIR}/include)
+set(ATMI_WRAPPER_BIN_DIR ${ATMI_WRAPPER_DIR}/bin)
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+  set(ATMI_LIB_NAME "lib-debug")
+else()
+  set(ATMI_LIB_NAME "lib")
+endif()
+set(ATMI_WRAPPER_LIB_DIR ${ATMI_WRAPPER_DIR}/${ATMI_LIB_NAME})
+
+set(PUBLIC_HEADERS
+    atmi.h
+    atmi_interop_hsa.h
+    atmi_runtime.h
+  )
+
+#Function to generate header template file
+function(create_header_template)
+    file(WRITE ${ATMI_WRAPPER_DIR}/header.hpp.in "/*
+    Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the \"Software\"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+   */\n\n#ifndef @include_guard@\n#define @include_guard@ \n\n\#warning This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\n@include_statements@ \n\n#endif")
+endfunction()
+
+
+#use header template file and generate wrapper header files
+function(generate_wrapper_header)
+  file(MAKE_DIRECTORY ${ATMI_WRAPPER_INC_DIR})
+  #Generate wrapper header files
+  foreach(header_file ${PUBLIC_HEADERS})
+    # set include guard
+    get_filename_component(INC_GAURD_NAME ${header_file} NAME_WE)
+    string(TOUPPER ${INC_GAURD_NAME} INC_GAURD_NAME)
+    set(include_guard "${include_guard}ATMI_WRAPPER_INCLUDE_${INC_GAURD_NAME}_H")
+    get_filename_component(file_name ${header_file} NAME)
+    #set include statements
+    set(include_statements "${include_statements}#include \"../../include/${PROJECT_NAME}/${file_name}\"\n")
+    configure_file(${ATMI_WRAPPER_DIR}/header.hpp.in ${ATMI_WRAPPER_INC_DIR}/${file_name})
+    unset(include_statements)
+  endforeach()
+
+endfunction()
+
+#function to create symlink to binaries
+function(create_binary_symlink)
+  file(MAKE_DIRECTORY ${ATMI_WRAPPER_BIN_DIR})
+  file(GLOB binaries ${CMAKE_CURRENT_SOURCE_DIR}/../bin/*)
+  foreach(binary_file ${binaries})
+    get_filename_component(file_name ${binary_file} NAME)
+    add_custom_target(link_${file_name} ALL
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                    COMMAND ${CMAKE_COMMAND} -E create_symlink
+                    ../../libexec/${PROJECT_NAME}/${file_name} ${ATMI_WRAPPER_BIN_DIR}/${file_name})
+  endforeach()
+endfunction()
+
+function(create_library_symlink)
+  file(MAKE_DIRECTORY ${ATMI_WRAPPER_LIB_DIR})
+  set(LIB_ATMI "libatmi_runtime.so")
+  #Resuing the code from runtime/core/Cmakelists.txt:
+  #This also need to be changed if Major or Minor version changes
+  set(LIB_VERSION_MAJOR 0)
+  set(LIB_VERSION_MINOR 7)
+  if(${ROCM_PATCH_VERSION})
+    set(LIB_VERSION_PATCH ${ROCM_PATCH_VERSION})
+  else()
+    set(LIB_VERSION_PATCH 0)
+  endif()
+  set(SO_VERSION "${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_PATCH}")
+  set(library_files "${LIB_ATMI}"  "${LIB_ATMI}.${LIB_VERSION_MAJOR}" "${LIB_ATMI}.${SO_VERSION}")
+  foreach(file_name ${library_files})
+     add_custom_target(link_${file_name} ALL
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  COMMAND ${CMAKE_COMMAND} -E create_symlink
+                  ../../${ATMI_LIB_NAME}/${file_name} ${ATMI_WRAPPER_LIB_DIR}/${file_name})
+  endforeach()
+endfunction()
+
+#Creater a template for header file
+create_header_template()
+#Use template header file and generater wrapper header files
+generate_wrapper_header()
+install(DIRECTORY ${ATMI_WRAPPER_INC_DIR} DESTINATION ${PROJECT_NAME} COMPONENT runtime)
+#Commenting this , since atmi binaries are conflicting with aomp and hipfort
+#AOMP-Extras package will provide the binaries
+# Create symlink to binaries
+#create_binary_symlink()
+#install(DIRECTORY ${ATMI_WRAPPER_BIN_DIR}  DESTINATION ${PROJECT_NAME} COMPONENT runtime)
+# Create symlink to libraries
+create_library_symlink()
+install(DIRECTORY ${ATMI_WRAPPER_LIB_DIR}  DESTINATION ${PROJECT_NAME} COMPONENT runtime)

--- a/src/atmi-backward-compat.cmake
+++ b/src/atmi-backward-compat.cmake
@@ -119,11 +119,9 @@ create_header_template()
 #Use template header file and generater wrapper header files
 generate_wrapper_header()
 install(DIRECTORY ${ATMI_WRAPPER_INC_DIR} DESTINATION ${PROJECT_NAME} COMPONENT runtime)
-#Commenting this , since atmi binaries are conflicting with aomp and hipfort
-#AOMP-Extras package will provide the binaries
 # Create symlink to binaries
-#create_binary_symlink()
-#install(DIRECTORY ${ATMI_WRAPPER_BIN_DIR}  DESTINATION ${PROJECT_NAME} COMPONENT runtime)
+create_binary_symlink()
+install(DIRECTORY ${ATMI_WRAPPER_BIN_DIR}  DESTINATION ${PROJECT_NAME} COMPONENT runtime)
 # Create symlink to libraries
 create_library_symlink()
 install(DIRECTORY ${ATMI_WRAPPER_LIB_DIR}  DESTINATION ${PROJECT_NAME} COMPONENT runtime)

--- a/src/atmi-backward-compat.cmake
+++ b/src/atmi-backward-compat.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 - 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+# Copyright (c) 2022 Advanced Micro Devices, Inc. All Rights Reserved.
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -39,7 +39,7 @@ set(PUBLIC_HEADERS
 #Function to generate header template file
 function(create_header_template)
     file(WRITE ${ATMI_WRAPPER_DIR}/header.hpp.in "/*
-    Copyright (c) 2015 - 2021 Advanced Micro Devices, Inc. All rights reserved.
+    Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the \"Software\"), to deal
@@ -58,9 +58,8 @@ function(create_header_template)
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
    THE SOFTWARE.
-   */\n\n#ifndef @include_guard@\n#define @include_guard@ \n\n\#warning This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\n@include_statements@ \n\n#endif")
+   */\n\n#ifndef @include_guard@\n#define @include_guard@ \n\n\#pragma message(\"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\")\n@include_statements@ \n\n#endif")
 endfunction()
-
 
 #use header template file and generate wrapper header files
 function(generate_wrapper_header)

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -150,16 +150,17 @@ endif()
 INSTALL(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi_runtime.h
-        DESTINATION "include"
+        DESTINATION "include/atmi"
         COMPONENT runtime
        )
-
-INSTALL(FILES
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/cloc.sh
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mymcpu
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mygpu
-      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/gputable.txt
-      PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      DESTINATION "bin"
-      COMPONENT runtime
-     )
+#Since the binaries are conflicting with aomp-extras and hipfort
+#removing from ATMI. aomp-extras will provide the same
+#INSTALL(FILES
+#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/cloc.sh
+#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mymcpu
+#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mygpu
+#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/gputable.txt
+#      PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+#     DESTINATION "libexec/atmi"
+#      COMPONENT runtime
+#     )

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -153,14 +153,12 @@ INSTALL(FILES
         DESTINATION "include/atmi"
         COMPONENT runtime
        )
-#Since the binaries are conflicting with aomp-extras and hipfort
-#removing from ATMI. aomp-extras will provide the same
-#INSTALL(FILES
-#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/cloc.sh
-#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mymcpu
-#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mygpu
-#      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/gputable.txt
-#      PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-#     DESTINATION "libexec/atmi"
-#      COMPONENT runtime
-#     )
+INSTALL(FILES
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/cloc.sh
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mymcpu
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mygpu
+      ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/gputable.txt
+      PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+      DESTINATION "libexec/atmi"
+      COMPONENT runtime
+     )

--- a/src/runtime/interop/hsa/CMakeLists.txt
+++ b/src/runtime/interop/hsa/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(interop_header ALL DEPENDS ${OUTPUT_INC_DIRECTORY}/atmi_intero
 
 INSTALL(FILES 
         ${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/atmi_interop_hsa.h
-        DESTINATION "include"
+        DESTINATION "include/atmi"
         COMPONENT runtime
        )
 


### PR DESCRIPTION
Atmi installed in /opt/rocm 
Binaries , header files and libraries installed in respective folders in /opt/rocm
For backward compatibility added wrapper header files
And softlink for binaries and library files