### PR TITLE
Use GNUInstallDirs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,9 @@ include (FindPackageHandleStandardArgs)
 
 project (atmi)
 
+# Set default libdir to be "lib" for ROCm, distros will override this anyway:
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")
+include(GNUInstallDirs)
 macro(libatmi_runtime_say_and_exit message_to_user)
   message(FATAL_ERROR "ATMI: ${message_to_user}")
 endmacro()
@@ -112,7 +115,7 @@ set ( CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERS
 set ( CPACK_PACKAGE_CONTACT "ATMI Support <atmi.support@amd.com>" )
 set ( CPACK_PACKAGE_DESCRIPTION_SUMMARY "Asynchronous Task and Memory Interface" )
 set ( CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.txt" )
-install( FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION share/doc/atmi COMPONENT runtime )
+install( FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDIR} COMPONENT runtime )
 
 if ( NOT DEFINED CPACK_PACKAGING_INSTALL_PREFIX )
     set ( CPACK_PACKAGING_INSTALL_PREFIX /opt/rocm )

--- a/src/atmi-backward-compat.cmake
+++ b/src/atmi-backward-compat.cmake
@@ -24,11 +24,13 @@ set(ATMI_WRAPPER_DIR ${ATMI_BUILD_DIR}/wrapper_dir)
 set(ATMI_WRAPPER_INC_DIR ${ATMI_WRAPPER_DIR}/include)
 set(ATMI_WRAPPER_BIN_DIR ${ATMI_WRAPPER_DIR}/bin)
 if(CMAKE_BUILD_TYPE MATCHES Debug)
-  set(ATMI_LIB_NAME "lib-debug")
+  set(ATMI_LIB_DIR "lib-debug")
+  set(ROCM_LIB_DIR "lib-debug")
 else()
-  set(ATMI_LIB_NAME "lib")
+  set(ATMI_LIB_DIR "lib")
+  set(ROCM_LIB_DIR "${CMAKE_INSTALL_LIBDIR}")
 endif()
-set(ATMI_WRAPPER_LIB_DIR ${ATMI_WRAPPER_DIR}/${ATMI_LIB_NAME})
+set(ATMI_WRAPPER_LIB_DIR ${ATMI_WRAPPER_DIR}/${ATMI_LIB_DIR})
 
 set(PUBLIC_HEADERS
     atmi.h
@@ -72,7 +74,7 @@ function(generate_wrapper_header)
     set(include_guard "${include_guard}ATMI_WRAPPER_INCLUDE_${INC_GAURD_NAME}_H")
     get_filename_component(file_name ${header_file} NAME)
     #set include statements
-    set(include_statements "${include_statements}#include \"../../include/${PROJECT_NAME}/${file_name}\"\n")
+    set(include_statements "${include_statements}#include \"../../${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${file_name}\"\n")
     configure_file(${ATMI_WRAPPER_DIR}/header.hpp.in ${ATMI_WRAPPER_INC_DIR}/${file_name})
     unset(include_statements)
   endforeach()
@@ -88,7 +90,7 @@ function(create_binary_symlink)
     add_custom_target(link_${file_name} ALL
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                     COMMAND ${CMAKE_COMMAND} -E create_symlink
-                    ../../libexec/${PROJECT_NAME}/${file_name} ${ATMI_WRAPPER_BIN_DIR}/${file_name})
+                    ../../${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}/${file_name} ${ATMI_WRAPPER_BIN_DIR}/${file_name})
   endforeach()
 endfunction()
 
@@ -110,7 +112,7 @@ function(create_library_symlink)
      add_custom_target(link_${file_name} ALL
                   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                   COMMAND ${CMAKE_COMMAND} -E create_symlink
-                  ../../${ATMI_LIB_NAME}/${file_name} ${ATMI_WRAPPER_LIB_DIR}/${file_name})
+                  ../../${ROCM_LIB_DIR}/${file_name} ${ATMI_WRAPPER_LIB_DIR}/${file_name})
   endforeach()
 endfunction()
 

--- a/src/compiler/CMakeLists.txt
+++ b/src/compiler/CMakeLists.txt
@@ -69,12 +69,12 @@ if(ROCM_FOUND)
             if(CMAKE_BUILD_TYPE MATCHES Debug)
                 install(TARGETS atmi_cplugin LIBRARY DESTINATION "lib-debug" COMPONENT cplugin )
             else()
-                install(TARGETS atmi_cplugin LIBRARY DESTINATION "lib" COMPONENT cplugin )
+                install(TARGETS atmi_cplugin LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT cplugin )
             endif()
             
             INSTALL(FILES
                 ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi_c_ext.h
-                DESTINATION "include"
+                DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
                 COMPONENT cplugin
             )
 

--- a/src/device_runtime/CMakeLists.txt
+++ b/src/device_runtime/CMakeLists.txt
@@ -148,7 +148,7 @@ foreach(mcpu ${mcpus})
 
   install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include/atmi_kl.h
-    DESTINATION include COMPONENT device_runtime)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT device_runtime)
 
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     install(FILES
@@ -158,7 +158,7 @@ foreach(mcpu ${mcpus})
   else()
     install(FILES
       ${OUTPUTDIR}/atmi-${mcpu}.bc
-      DESTINATION lib COMPONENT device_runtime
+      DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT device_runtime
       )
   endif()
 endforeach()

--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -144,13 +144,13 @@ add_custom_target(core_header ALL DEPENDS ${OUTPUT_INC_DIRECTORY}/atmi.h ${OUTPU
 if(CMAKE_BUILD_TYPE MATCHES Debug)
   install(TARGETS atmi_runtime LIBRARY DESTINATION "lib-debug" COMPONENT runtime )
 else()
-  install(TARGETS atmi_runtime LIBRARY DESTINATION "lib" COMPONENT runtime )
+  install(TARGETS atmi_runtime LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT runtime )
 endif()
 
 INSTALL(FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi.h
         ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/atmi_runtime.h
-        DESTINATION "include/atmi"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atmi"
         COMPONENT runtime
        )
 INSTALL(FILES
@@ -159,6 +159,6 @@ INSTALL(FILES
       ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/mygpu
       ${CMAKE_CURRENT_SOURCE_DIR}/../../../bin/gputable.txt
       PERMISSIONS OWNER_EXECUTE OWNER_READ GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
-      DESTINATION "libexec/atmi"
+      DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/atmi"
       COMPONENT runtime
      )

--- a/src/runtime/interop/hsa/CMakeLists.txt
+++ b/src/runtime/interop/hsa/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(interop_header ALL DEPENDS ${OUTPUT_INC_DIRECTORY}/atmi_intero
 
 INSTALL(FILES 
         ${CMAKE_CURRENT_SOURCE_DIR}/../../../../include/atmi_interop_hsa.h
-        DESTINATION "include/atmi"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/atmi"
         COMPONENT runtime
        )
 


### PR DESCRIPTION
Use GNUInstallDirs variables to determine the location of INCLUDEDIR,
LIBDIR, DOCDIR, and LIBEXECDIR.

Note that CMAKE_INSTALL_LIBDIR is overriden, since the default for RHEL
is lib64, but ROCm packaging wants it to be lib always. Distros or users
can easily override this.