### PR TITLE
SWDEV-344894 - Fix build error in atmi spack

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,15 +39,6 @@ endif()
 endif()
 
 option(FILE_REORG_BACKWARD_COMPATIBILITY "Enable File Reorg with backward compatibility" ON)
-#TODO: The string replace statements can be removed once build scripts changes are merged
-if(FILE_REORG_BACKWARD_COMPATIBILITY)
-  if(CMAKE_INSTALL_PREFIX)
-    string(REPLACE "/atmi" "" CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-  endif()
-  if(CPACK_PACKAGING_INSTALL_PREFIX)
-    string(REPLACE "/atmi" "" CPACK_PACKAGING_INSTALL_PREFIX ${CPACK_PACKAGING_INSTALL_PREFIX})
-  endif()
-endif()
 ################################################################################
 # Looking for ROCM...
 ################################################################################


### PR DESCRIPTION
Build script was passing destination as "atmi" in cmake prefix path and cpack packing prefix
For file reorganization, added workaround in source code to remove the destination name from those parameters.
This is causing issue in atmi spack build. Made changes in atmi build script, so that the workaround can be removed from source code

Depends-On: I2c79675ec05e1e7de2baa0a21033939f0eadac3d