### PR TITLE
SWDEV-345870 - Correct include paths for new directory layout

### DIFF
--- a/include/atmi_interop_hsa.h
+++ b/include/atmi_interop_hsa.h
@@ -7,8 +7,8 @@
 #define INCLUDE_ATMI_INTEROP_HSA_H_
 
 #include "atmi_runtime.h"
-#include "hsa.h"
-#include "hsa_ext_amd.h"
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cmake_modules/FindROCm.cmake
+++ b/src/cmake_modules/FindROCm.cmake
@@ -16,25 +16,12 @@
 
 find_path(
   ROCM_INCLUDE_DIRS
-    hsa.h
+    hsa/hsa.h
   HINTS
     ${ROC_DIR}/include
-    ${ROC_DIR}/include/hsa
-    ${ROC_DIR}/hsa/include
-    ${ROC_DIR}/hsa/include/hsa
-    ${ROC_DIR}/hsa
-    ${ROC_DIR}
     ${ROCR_DIR}/include
-    ${ROCR_DIR}/include/hsa
-    ${ROCR_DIR}/hsa/include
-    ${ROCR_DIR}/hsa/include/hsa
-    ${ROCR_DIR}
     /opt/rocm/include
-    /opt/rocm/hsa/include
-    /usr/local/include
     ENV CPATH
-  PATH_SUFFIXES
-    hsa
 )
 
 find_library(
@@ -46,7 +33,6 @@ find_library(
     ${ROCR_DIR}/lib
     ${ROCR_DIR}
     /opt/rocm/lib
-    /opt/rocm/hsa/lib
     /usr/local/lib
     /usr/lib/x86_64-linux-gnu
     /usr/lib
@@ -62,7 +48,6 @@ find_library(
     ${ROCT_DIR}/lib
     ${ROCT_DIR}
     /opt/rocm/lib
-    /opt/rocm/hsa/lib
     /usr/local/lib
     /usr/lib/x86_64-linux-gnu
     /usr/lib

--- a/src/runtime/core/data.cpp
+++ b/src/runtime/core/data.cpp
@@ -4,8 +4,8 @@
  * This file is distributed under the MIT License. See LICENSE.txt for details.
  *===------------------------------------------------------------------------*/
 #include "data.h"
-#include <hsa.h>
-#include <hsa_ext_amd.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 #include <stdio.h>
 #include <string.h>
 #include <cassert>

--- a/src/runtime/core/machine.cpp
+++ b/src/runtime/core/machine.cpp
@@ -4,8 +4,8 @@
  * This file is distributed under the MIT License. See LICENSE.txt for details.
  *===------------------------------------------------------------------------*/
 #include "machine.h"
-#include <hsa.h>
-#include <hsa_ext_amd.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <cassert>

--- a/src/runtime/core/queue.cpp
+++ b/src/runtime/core/queue.cpp
@@ -5,7 +5,7 @@
  *===------------------------------------------------------------------------*/
 #include "queue.h"
 #include "atmi.h"
-#include "hsa_ext_amd.h"
+#include "hsa/hsa_ext_amd.h"
 
 bool equalsPlace(const atmi_place_t &l, const atmi_place_t &r) {
   bool val = false;

--- a/src/runtime/core/task.cpp
+++ b/src/runtime/core/task.cpp
@@ -40,7 +40,7 @@ pthread_mutex_t mutex_readyq_;
 #define NANOSECS 1000000000L
 
 //  set NOTCOHERENT needs this include
-#include "hsa_ext_amd.h"
+#include "hsa/hsa_ext_amd.h"
 
 extern bool handle_signal(hsa_signal_value_t value, void *arg);
 

--- a/src/runtime/include/data.h
+++ b/src/runtime/include/data.h
@@ -5,7 +5,7 @@
  *===------------------------------------------------------------------------*/
 #ifndef SRC_RUNTIME_INCLUDE_DATA_H_
 #define SRC_RUNTIME_INCLUDE_DATA_H_
-#include <hsa.h>
+#include <hsa/hsa.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <map>

--- a/src/runtime/include/device_rt_internal.h
+++ b/src/runtime/include/device_rt_internal.h
@@ -9,7 +9,7 @@
 #ifdef __OPENCL_C_VERSION__
 #include "device_amd_hsa.h"
 #else
-#include <hsa.h>
+#include <hsa/hsa.h>
 #endif
 
 #define MAX_NUM_KERNELS (1024 * 16)

--- a/src/runtime/include/internal.h
+++ b/src/runtime/include/internal.h
@@ -21,9 +21,9 @@
 #include <utility>
 #include <vector>
 
-#include "hsa.h"
-#include "hsa_ext_amd.h"
-#include "hsa_ext_finalize.h"
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+#include "hsa/hsa_ext_finalize.h"
 
 #include "atmi.h"
 #include "atmi_runtime.h"

--- a/src/runtime/include/machine.h
+++ b/src/runtime/include/machine.h
@@ -5,8 +5,8 @@
  *===------------------------------------------------------------------------*/
 #ifndef SRC_RUNTIME_INCLUDE_MACHINE_H_
 #define SRC_RUNTIME_INCLUDE_MACHINE_H_
-#include <hsa.h>
-#include <hsa_ext_amd.h>
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
 #include <vector>
 #include "atmi.h"
 #include "internal.h"

--- a/src/runtime/include/queue.h
+++ b/src/runtime/include/queue.h
@@ -7,7 +7,7 @@
 #define SRC_RUNTIME_INCLUDE_QUEUE_H_
 
 #include "atmi.h"
-#include "hsa.h"
+#include "hsa/hsa.h"
 class ATLQueue {
  public:
   explicit ATLQueue(hsa_queue_t *q, atmi_place_t p = ATMI_PLACE_ANY(0))

--- a/src/runtime/include/rt.h
+++ b/src/runtime/include/rt.h
@@ -7,7 +7,7 @@
 #define SRC_RUNTIME_INCLUDE_RT_H_
 
 #include <atmi_runtime.h>
-#include <hsa.h>
+#include <hsa/hsa.h>
 #include <cstdarg>
 #include <string>
 

--- a/src/runtime/include/taskgroup.h
+++ b/src/runtime/include/taskgroup.h
@@ -7,7 +7,7 @@
 #ifndef SRC_RUNTIME_INCLUDE_TASKGROUP_H_
 #define SRC_RUNTIME_INCLUDE_TASKGROUP_H_
 
-#include <hsa.h>
+#include <hsa/hsa.h>
 
 #include <deque>
 #include <queue>


### PR DESCRIPTION
Use actual hsa header files rather than using wrapper header files . This will fix the warning message during build.
Also atmi will build successfully once hsa backward compatibility is turned off