### PR TITLE
Correct include path for new directory layout

### DIFF
--- a/src/runtime/core/CMakeLists.txt
+++ b/src/runtime/core/CMakeLists.txt
@@ -13,25 +13,9 @@ include_directories(${LIBELF_INCLUDE_DIRS})
 # libatmi_runtime_say("LIBELF: ${LIBELF_INCLUDE_DIRS} ${LIBELF_LIBRARIES} and ${LIBELF_FOUND}")
 
 # Find comgr
-find_package(amd_comgr REQUIRED CONFIG
-             HINTS ${ROC_DIR} ${ROC_COMGR_CONFIG_DIR})
-find_path (amd_comgr_INCLUDE_DIRS
-    NAMES
-    amd_comgr.h
-    PATHS
-    ${ROCM_INCLUDE_DIRS}
-    ${ROC_DIR}
-    ${ROC_COMGR_INCLUDE_DIR}
-    ${ROC_COMGR_INCLUDE_DIR}/include
-    /opt/rocm/include
-    /usr/include
-    /usr/local/include
-    ENV CPATH
-    PATH_SUFFIXES include)
+find_package(amd_comgr REQUIRED)
 
 set(amd_comgr_LIBRARIES amd_comgr)
-include_directories(${amd_comgr_INCLUDE_DIRS})
-# libatmi_runtime_say("amd_comgr: ${amd_comgr_INCLUDE_DIRS} ${amd_comgr_LIBRARIES} and ${amd_comgr_FOUND}")
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(ppc64le)|(aarch64)$")
    add_definitions(-DLITTLEENDIAN_CPU=1)


### PR DESCRIPTION
SWDEV-345870 - Instead of finding the header path using header files use the install interface provided by the package