### PR TITLE
Correct include path for new directory layout

### DIFF
--- a/src/runtime/core/system.cpp
+++ b/src/runtime/core/system.cpp
@@ -14,7 +14,7 @@
 #include <set>
 #include <string>
 
-#include "amd_comgr.h"
+#include "amd_comgr/amd_comgr.h"
 #include "device_rt_internal.h"
 #include "internal.h"
 #include "machine.h"


### PR DESCRIPTION
SWDEV-345870 : Use actual header file amd_comgr.h rather than using wrapper file