### PR TITLE
SWDEV-366823 - Change pragma message to warning

### DIFF
--- a/src/atmi-backward-compat.cmake
+++ b/src/atmi-backward-compat.cmake
@@ -60,7 +60,20 @@ function(create_header_template)
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
    THE SOFTWARE.
-   */\n\n#ifndef @include_guard@\n#define @include_guard@ \n\n\#pragma message(\"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\")\n@include_statements@ \n\n#endif")
+   */
+
+#ifndef @include_guard@
+#define @include_guard@
+
+#if defined(_MSC_VER)
+#pragma message(\"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\")
+#elif defined(__GNUC__)
+#warning \"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\"
+#endif
+
+@include_statements@
+
+#endif")
 endfunction()
 
 #use header template file and generate wrapper header files


### PR DESCRIPTION
File reorganization feature was implemented with backward compatibility The backward compatibility support will be deprecated in future release. Changed the #pragma message to #warning for a smooth transition