### PR TITLE
SWDEV-366831 - Compile time flag to switch between #warning and #erro…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,21 @@ add_subdirectory(compiler)
 add_subdirectory(device_runtime)
 
 if(FILE_REORG_BACKWARD_COMPATIBILITY)
+# To enable disable #error  in wrapper header files
+  if(NOT DEFINED ROCM_HEADER_WRAPPER_WERROR)
+      if(DEFINED ENV{ROCM_HEADER_WRAPPER_WERROR})
+          set(ROCM_HEADER_WRAPPER_WERROR "$ENV{ROCM_HEADER_WRAPPER_WERROR}"
+                  CACHE STRING "Header wrapper warnings as errors.")
+      else()
+          set(ROCM_HEADER_WRAPPER_WERROR "ON" CACHE STRING "Header wrapper warnings as errors.")
+      endif()
+  endif()
+  if(ROCM_HEADER_WRAPPER_WERROR)
+      set(deprecated_error 1)
+  else()
+      set(deprecated_error 0)
+  endif()
+
   include(atmi-backward-compat.cmake)
 endif()
 # make examples available in local build

--- a/src/atmi-backward-compat.cmake
+++ b/src/atmi-backward-compat.cmake
@@ -65,11 +65,18 @@ function(create_header_template)
 #ifndef @include_guard@
 #define @include_guard@
 
-#if defined(__GNUC__)
+#ifndef ROCM_HEADER_WRAPPER_WERROR
+#define ROCM_HEADER_WRAPPER_WERROR @deprecated_error@
+#endif
+#if ROCM_HEADER_WRAPPER_WERROR  /* ROCM_HEADER_WRAPPER_WERROR 1 */
 #error \"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\"
+#else     /* ROCM_HEADER_WRAPPER_WERROR 0 */
+#if defined(__GNUC__)
+#warning \"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\"
 #else
 #pragma message(\"This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with atmi\")
 #endif
+#endif  /* ROCM_HEADER_WRAPPER_WERROR */
 
 @include_statements@
 


### PR DESCRIPTION
Using backward compatibility paths will provide an #error message. 
Compile time option added to enable/disable the #error message. Disabling the same will provide a #warning message