### PR TITLE
SWDEV-383221 - Set the default value of ROCM_HEADER_WRAPPER_WERROR to OFF

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ if(FILE_REORG_BACKWARD_COMPATIBILITY)
           set(ROCM_HEADER_WRAPPER_WERROR "$ENV{ROCM_HEADER_WRAPPER_WERROR}"
                   CACHE STRING "Header wrapper warnings as errors.")
       else()
-          set(ROCM_HEADER_WRAPPER_WERROR "ON" CACHE STRING "Header wrapper warnings as errors.")
+          set(ROCM_HEADER_WRAPPER_WERROR "OFF" CACHE STRING "Header wrapper warnings as errors.")
       endif()
   endif()
   if(ROCM_HEADER_WRAPPER_WERROR)


### PR DESCRIPTION
Using wrapper header files will result in #warning message by default